### PR TITLE
Patch to support networking.k8s.io/v1 Ingresses on 0.1.x versions of the Chart / ISPN 12.1.x.  Bind to 0.0.0.0

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -3,7 +3,7 @@ name: infinispan
 description: A Helm chart that lets you build and deploy Infinispan clusters.
 type: application
 # Chart version
-version: 0.1.0
+version: 0.1.1
 # Infinispan version. Use the floating x.y tag of the image.
 appVersion: "12.1"
 icon: https://design.jboss.org/infinispan/logo/final/PNG/infinispan_icon_rgb_lightbluewhite_256px.png

--- a/templates/route.yaml
+++ b/templates/route.yaml
@@ -22,8 +22,8 @@ spec:
   to:
     kind: Service
     name: {{ include "infinispan-helm-charts.name" . }}
-  {{- else if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1/Ingress" }}
-apiVersion: networking.k8s.io/v1beta1
+  {{- else if or (.Capabilities.APIVersions.Has "networking.k8s.io/v1") (.Capabilities.APIVersions.Has "networking.k8s.io/v1beta1/Ingress") }}
+apiVersion: {{ if .Capabilities.APIVersions.Has "networking.k8s.io/v1" }}networking.k8s.io/v1{{ else }}networking.k8s.io/v1beta1{{ end }}
 kind: Ingress
 metadata:
   name: {{ include "infinispan-helm-charts.name" . }}
@@ -38,23 +38,22 @@ metadata:
   {{- end }}
 spec:
   rules:
-    {{- if .Values.deploy.expose.host }}
-    - host: {{ .Values.deploy.expose.host | quote }}
-      http:
-        paths:
-          - path: /
-            pathType: Prefix
-            backend:
-              serviceName: {{ include "infinispan-helm-charts.name" . }}
-              servicePort: 11222
-    {{- else }}
     - http:
         paths:
           - path: /
             pathType: Prefix
             backend:
+            {{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
+              service:
+                name: {{ include "infinispan-helm-charts.name" . }}
+                port:
+                  number: 11222
+            {{- else }}
               serviceName: {{ include "infinispan-helm-charts.name" . }}
               servicePort: 11222
+            {{- end }}
+      {{- if .Values.deploy.expose.host }}
+      host: {{ .Values.deploy.expose.host | quote }}
+      {{- end }}
   {{- end }}
-  {{- end }}
-  {{- end }}
+{{- end }}

--- a/templates/statefulset.yaml
+++ b/templates/statefulset.yaml
@@ -63,7 +63,7 @@ spec:
               --cluster-name={{ include "infinispan-helm-charts.name" . }}
               --server-config=/etc/config/infinispan.xml
               --logging-config=/etc/config/log4j2.xml
-              --bind-address=$HOSTNAME
+              --bind-address=0.0.0.0
               -Djgroups.dns.query={{ printf "%s-ping.%s.svc.cluster.local" (include "infinispan-helm-charts.name" .) .Release.Namespace }}
           ports:
             - containerPort: 8888


### PR DESCRIPTION
Similar to #19, needed to support the new K8S Ingress types, but with the older version of ISPN (12.1.x)

Followed similar fix to #19 but made it conditional based on existence of API types.

Also now bind to 0.0.0.0 as per k8s convention (and also set as such in 0.2.x versions of the chart)