### PR TITLE
Feature/add ability to set k8s cluster domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Configure your Infinispan cluster by specifying values in the `deploy.*` section
 
 | Value | Description | Default | Additional Information |
 | ----- | ----------- | ------- | ---------------------- |
-| `deploy.clusterDomain` | The internal Kubernetes cluster domain. | cluster.local | - |
+| `deploy.clusterDomain` | Specifies the internal Kubernetes cluster domain. | cluster.local | - |
 | `deploy.replicas` | Specifies the number of nodes in your Infinispan cluster, with a pod created for each node. | 1 | - |
 | `deploy.container.extraJvmOpts` | Passes JVM options to Infinispan Server. | `""` | - |
 | `deploy.container.storage.ephemeral` | Defines whether storage is ephemeral or permanent. | false | Set the value to `true` to use ephemeral storage, which means all stored data is deleted when clusters shut down or restart. |

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Configure your Infinispan cluster by specifying values in the `deploy.*` section
 
 | Value | Description | Default | Additional Information |
 | ----- | ----------- | ------- | ---------------------- |
+| `deploy.clusterDomain` | The internal Kubernetes cluster domain. | cluster.local | - |
 | `deploy.replicas` | Specifies the number of nodes in your Infinispan cluster, with a pod created for each node. | 1 | - |
 | `deploy.container.extraJvmOpts` | Passes JVM options to Infinispan Server. | `""` | - |
 | `deploy.container.storage.ephemeral` | Defines whether storage is ephemeral or permanent. | false | Set the value to `true` to use ephemeral storage, which means all stored data is deleted when clusters shut down or restart. |
@@ -34,7 +35,7 @@ Configure your Infinispan cluster by specifying values in the `deploy.*` section
 | `deploy.expose.annotations` | Adds annotations to the service that exposes Infinispan on the network. | `{}` | - |
 | `deploy.logging.categories` | Configures Infinispan cluster log categories and levels. | `{}` | - |
 | `deploy.podLabels` | Adds labels to each Infinispan pod that you create. | `{}` | - |
-| `deploy.svcLabels` | Adds labels to each service that you create. | `{}` | - |
+| `deploy.svcLabels` | Adds labels to each service that you create.| `{}` | - |
 | `deploy.resourceLabels` | Adds labels to all Infinispan resources including pods and services. | `{}` | - |
 | `deploy.makeDataDirWritable` | Allows write access to the `data` directory for each Infinispan Server node. | false | Setting the value to `true` creates an initContainer that runs `chmod -R` on the `/opt/infinispan/server/data` directory and changes its permissions. |
 | `deploy.monitoring.enabled` | Enable/disable ServiceMonitor functionality. | true | - |

--- a/README.md.tpl
+++ b/README.md.tpl
@@ -17,6 +17,7 @@ Configure your {brandname} cluster by specifying values in the `deploy.*` sectio
 
 | Value | Description | Default | Additional Information |
 | ----- | ----------- | ------- | ---------------------- |
+| `deploy.clusterDomain` | The internal Kubernetes cluster domain. | cluster.local | - |
 | `deploy.replicas` | Specifies the number of nodes in your {brandname} cluster, with a pod created for each node. | 1 | - |
 | `deploy.container.extraJvmOpts` | Passes JVM options to {brandname} Server. | `""` | - |
 | `deploy.container.storage.ephemeral` | Defines whether storage is ephemeral or permanent. | false | Set the value to `true` to use ephemeral storage, which means all stored data is deleted when clusters shut down or restart. |

--- a/README.md.tpl
+++ b/README.md.tpl
@@ -17,7 +17,7 @@ Configure your {brandname} cluster by specifying values in the `deploy.*` sectio
 
 | Value | Description | Default | Additional Information |
 | ----- | ----------- | ------- | ---------------------- |
-| `deploy.clusterDomain` | The internal Kubernetes cluster domain. | cluster.local | - |
+| `deploy.clusterDomain` | Specifies the internal Kubernetes cluster domain. | cluster.local | - |
 | `deploy.replicas` | Specifies the number of nodes in your {brandname} cluster, with a pod created for each node. | 1 | - |
 | `deploy.container.extraJvmOpts` | Passes JVM options to {brandname} Server. | `""` | - |
 | `deploy.container.storage.ephemeral` | Defines whether storage is ephemeral or permanent. | false | Set the value to `true` to use ephemeral storage, which means all stored data is deleted when clusters shut down or restart. |

--- a/templates/statefulset.yaml
+++ b/templates/statefulset.yaml
@@ -62,7 +62,7 @@ spec:
             - --server-config=/etc/config/infinispan.yml
             - --logging-config=/etc/config/log4j2.xml
             - --bind-address=0.0.0.0
-            - -Djgroups.dns.query={{ printf "%s-ping.%s.svc.cluster.local" (include "infinispan-helm-charts.name" .) .Release.Namespace }}
+            - -Djgroups.dns.query={{ printf "%s-ping.%s.svc.%s" (include "infinispan-helm-charts.name" .) .Release.Namespace .Values.deploy.clusterDomain }}
           ports:
             - containerPort: 8888
               name: ping

--- a/values.schema.json
+++ b/values.schema.json
@@ -40,6 +40,11 @@
                     ]
                 },
                 "replicas": {
+                    "description": "The internal Kubernetes cluster domain.",
+                    "type": "string",
+                    "default": "cluster.local"
+                },
+                "replicas": {
                     "description": "Number of pods in the Infinispan cluster.",
                     "type": "integer"
                 },

--- a/values.schema.json
+++ b/values.schema.json
@@ -39,8 +39,8 @@
                         "null"
                     ]
                 },
-                "replicas": {
-                    "description": "The internal Kubernetes cluster domain.",
+                "clusterDomain": {
+                    "description": "Specifies the internal Kubernetes cluster domain.",
                     "type": "string",
                     "default": "cluster.local"
                 },

--- a/values.schema.json.tpl
+++ b/values.schema.json.tpl
@@ -39,8 +39,8 @@
                         "null"
                     ]
                 },
-                "replicas": {
-                    "description": "The internal Kubernetes cluster domain.",
+                "clusterDomain": {
+                    "description": "Specifies the internal Kubernetes cluster domain.",
                     "type": "string",
                     "default": "cluster.local"
                 },

--- a/values.schema.json.tpl
+++ b/values.schema.json.tpl
@@ -40,6 +40,11 @@
                     ]
                 },
                 "replicas": {
+                    "description": "The internal Kubernetes cluster domain.",
+                    "type": "string",
+                    "default": "cluster.local"
+                },
+                "replicas": {
                     "description": "Number of pods in the {brandname} cluster.",
                     "type": "integer"
                 },

--- a/values.yaml
+++ b/values.yaml
@@ -11,6 +11,8 @@ deploy:
   # [USER] Specify the number of nodes in the cluster.
   replicas: 1
 
+  clusterDomain: cluster.local
+
   container:
     extraJvmOpts: ""
     storage:


### PR DESCRIPTION
Hi, 
If k8s cluster has different from `cluster.local` domain, then deployed nodes unable to discover each other, so added ability to set k8s cluster domain. 