### PR TITLE
Fixed metrics service selector and metrics service port name

### DIFF
--- a/templates/metrics-service.yaml
+++ b/templates/metrics-service.yaml
@@ -15,6 +15,6 @@ spec:
   ports:
     - port: 11223
       protocol: TCP
-      name: infinispan
+      name: infinispan-met
   selector:
   {{- include "infinispan-helm-charts.selectorLabels" . | nindent 4 }}

--- a/templates/service-monitor.yaml
+++ b/templates/service-monitor.yaml
@@ -30,6 +30,6 @@ spec:
       - {{ .Release.Namespace }}
   selector:
     matchLabels:
-      app: infinispan-service
+      app: infinispan-service-metrics
       clusterName: {{ include "infinispan-helm-charts.name" . }}
 {{- end }}


### PR DESCRIPTION
Hi, 
there is bug in metrics scrapping configuration:
1. `Servicemonitor` has invalid `app` label selector value - there must be metrics service `app` label value;
2. In `Servicemonitor` expected port name is `infinispan-met`, but in service it named as `infinispan`. 

Have a look on fixes.