### PR TITLE
Add documentation for deploy.clusterDomain

### DIFF
--- a/documentation/asciidoc/topics/ref_deployment_configuration_values.adoc
+++ b/documentation/asciidoc/topics/ref_deployment_configuration_values.adoc
@@ -13,6 +13,10 @@ You can also find field and value descriptions in the link:{helm_chart_readme}[{
 |===
 |Field |Description |Default value
 
+|`deploy.clusterDomain`
+|Specifies the internal Kubernetes cluster domain.
+|`cluster.local`
+
 |`deploy.replicas`
 |Specifies the number of nodes in your {brandname} cluster, with a pod created for each node.
 |`1`

--- a/documentation/asciidoc/topics/yaml/infinispan_values.yaml
+++ b/documentation/asciidoc/topics/yaml/infinispan_values.yaml
@@ -9,3 +9,5 @@ deploy:
     batch: "user create admin -p changeme"
   #Create a cluster with two pods.
   replicas: 2
+  #Specify the internal Kubernetes cluster domain.
+  clusterDomain: cluster.local


### PR DESCRIPTION
Adds the required `deploy.clusterDomain` field. If running a helm install with a values file, and this property isn't provided, clustering breaks due to the missing parameter in `jgroups.dns.query`:
```
-Djgroups.dns.query=infinispan-cluster-ping.rhdg-ocp-demo.svc.%!s(<nil>)
```
See also [this commit](https://github.com/infinispan/infinispan-helm-charts/commit/621339c1cf3ef8a9d2e7a246a7ea7edeafa1fe5e).