### PR TITLE
Adding log volume and posibility to provide pod annotations

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Configure your Infinispan cluster by specifying values in the `deploy.*` section
 | `deploy.expose.host` | Specifies the hostname where the Ingress is exposed, if required. | `""` | |
 | `deploy.expose.annotations` | Adds annotations to the service that exposes Infinispan on the network. | `{}` | - |
 | `deploy.logging.categories` | Configures Infinispan cluster log categories and levels. | `{}` | - |
+| `deploy.podAnnotations` | Adds annotations to each Infinispan pod that you create. | `{}` | - |
 | `deploy.podLabels` | Adds labels to each Infinispan pod that you create. | `{}` | - |
 | `deploy.svcLabels` | Adds labels to each service that you create.| `{}` | - |
 | `deploy.resourceLabels` | Adds labels to all Infinispan resources including pods and services. | `{}` | - |

--- a/README.md.tpl
+++ b/README.md.tpl
@@ -37,6 +37,7 @@ Configure your {brandname} cluster by specifying values in the `deploy.*` sectio
 | `deploy.expose.host` | Specifies the hostname where the {ingress} is exposed, if required. | `""` | |
 | `deploy.expose.annotations` | Adds annotations to the service that exposes {brandname} on the network. | `{}` | - |
 | `deploy.logging.categories` | Configures {brandname} cluster log categories and levels. | `{}` | - |
+| `deploy.podAnnotations` | Adds annotations to each Infinispan pod that you create. | `{}` | - |
 | `deploy.podLabels` | Adds labels to each Infinispan pod that you create. | `{}` | - |
 | `deploy.svcLabels` | Adds labels to each service that you create.| `{}` | - |
 | `deploy.resourceLabels` | Adds labels to all {brandname} resources including pods and services. | `{}` | - |

--- a/templates/helpers.tpl
+++ b/templates/helpers.tpl
@@ -42,6 +42,16 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}
 
 {{/*
+Pod custom Annotations
+*/}}
+
+{{- define "infinispan-helm-charts.podAnnotations" -}}
+{{- range .Values.deploy.podAnnotations }}
+{{ .key }}: {{ .value }}
+{{- end }}
+{{- end }}
+
+{{/*
 Pod custom labels
 */}}
 

--- a/templates/statefulset.yaml
+++ b/templates/statefulset.yaml
@@ -21,7 +21,8 @@ spec:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
         {{- if not (.Values.deploy.security.secretName) }}
         checksum/identities: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
-      {{- end }}
+        {{- end }}
+        {{- include "infinispan-helm-charts.podAnnotations" . | nindent 8 }}
       labels:
         app: infinispan-pod
         clusterName: {{ include "infinispan-helm-charts.name" . }}
@@ -135,6 +136,8 @@ spec:
               name: config-volume
             - mountPath: /opt/infinispan/server/data
               name: data-volume
+            - mountPath: /opt/infinispan/server/log
+              name: log-volume
             - mountPath: /etc/security
               name: identities-volume
           {{- if  and .Values.deploy.ssl (ne .Values.deploy.ssl.transportSecretName "")}}
@@ -166,6 +169,8 @@ spec:
         - name: data-volume
           emptyDir: { }
         {{- end }}
+        - name: log-volume
+          emptyDir: { }
       {{- with .Values.deploy.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}

--- a/values.schema.json
+++ b/values.schema.json
@@ -311,6 +311,27 @@
                         }
                     }
                 },
+                "podAnnotations": {
+                    "description": "Adds annotations to every pod created",
+                    "items": {
+                        "properties": {
+                            "key": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "key",
+                            "value"
+                        ]
+                    },
+                    "type": [
+                        "array",
+                        "null"
+                    ]
+                },
                 "podLabels": {
                     "description": "Adds labels to every pod created",
                     "items": {

--- a/values.schema.json.tpl
+++ b/values.schema.json.tpl
@@ -311,6 +311,27 @@
                         }
                     }
                 },
+                "podAnnotations": {
+                    "description": "Adds annotations to every pod created",
+                    "items": {
+                        "properties": {
+                            "key": {
+                                "type": "string"
+                            },
+                            "value": {
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "key",
+                            "value"
+                        ]
+                    },
+                    "type": [
+                        "array",
+                        "null"
+                    ]
+                },
                 "podLabels": {
                     "description": "Adds labels to every pod created",
                     "items": {

--- a/values.yaml
+++ b/values.yaml
@@ -76,6 +76,8 @@ deploy:
 
   resourceLabels: []
 
+  podAnnotations: []
+
   podLabels: []
 
   svcLabels: []


### PR DESCRIPTION
Hi,

I am working with log data collections from infinispan. I have added 2 elements to the helm chart.
1. A volume dedicated to logs, which can easy be mounted into a sidecar.
2. Posible to provide custom annotations, this could for example be for opentelemetry injection of sidecar og code level injection.

What do you think ?