### PR TITLE
Add posibility for custom volumes

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,4 +52,6 @@ Configure your Infinispan cluster by specifying values in the `deploy.*` section
 | `deploy.securityContext` | Defines the securityContext settings used by the cluster's StatefulSet | `{}` | - |
 | `deploy.ssl.endpointSecretName` | Specifies the name of the secret that contains certificate for endpoint encryption | `""` | - |
 | `deploy.ssl.transportSecretName` | Specifies the name of the secret that contains certificate for transport encryption | `""` | - |
+| `deploy.volumeMounts` | Add custome volume mounts to infinispan | `[]` | - |
+| `deploy.volumes` | Add custome volumes to infinispan | `[]` | - |
 | `deploy.infinispan` | Infinispan Server configuration. | - | You should not change the default socket bindings or the security realm and endpoints named "metrics". Modifying these default properties can result in unexpected behavior and loss of service. |

--- a/README.md.tpl
+++ b/README.md.tpl
@@ -52,4 +52,6 @@ Configure your {brandname} cluster by specifying values in the `deploy.*` sectio
 | `deploy.securityContext` | Defines the securityContext settings used by the cluster's StatefulSet | `{}` | - |
 | `deploy.ssl.endpointSecretName` | Specifies the name of the secret that contains certificate for endpoint encryption | `""` | - |
 | `deploy.ssl.transportSecretName` | Specifies the name of the secret that contains certificate for transport encryption | `""` | - |
+| `deploy.volumeMounts` | Add custome volume mounts to infinispan | `[]` | - |
+| `deploy.volumes` | Add custome volumes to infinispan | `[]` | - |
 | `deploy.infinispan` | {brandname} Server configuration. | - | You should not change the default socket bindings or the security realm and endpoints named "metrics". Modifying these default properties can result in unexpected behavior and loss of service. |

--- a/templates/statefulset.yaml
+++ b/templates/statefulset.yaml
@@ -149,6 +149,9 @@ spec:
             - mountPath: "/etc/encrypt/endpoint"
               name: "encrypt-volume"
           {{- end }}
+          {{- with .Values.deploy.volumeMounts }}
+          {{- toYaml . | nindent 12 }}
+          {{- end }}
       volumes:
         - configMap:
             name: {{ printf "%s-configuration" (include "infinispan-helm-charts.name" .) }}
@@ -169,6 +172,9 @@ spec:
         {{- if .Values.deploy.container.storage.ephemeral }}
         - name: data-volume
           emptyDir: { }
+        {{- end }}
+        {{- with .Values.deploy.volumes }}
+        {{- toYaml . | nindent 8 }}
         {{- end }}
       {{- with .Values.deploy.tolerations }}
       tolerations:

--- a/values.schema.json
+++ b/values.schema.json
@@ -422,6 +422,39 @@
                         "null"
                     ]
                 },
+                "volumeMounts": {
+                    "description": "Add custome volume mounts to infinispan",
+                    "items": {
+                        "properties": {
+                            "name": {
+                                "type": "string"
+                            },
+                            "mountPath": {
+                                "type": "string"
+                            }
+                        },
+                        "additionalProperties": true
+                    },
+                    "type": [
+                        "array",
+                        "null"
+                    ]
+                },
+                "volumes": {
+                    "description": "Add custome volumes to infinispan",
+                    "items": {
+                        "properties": {
+                            "name": {
+                                "type": "string"
+                            }
+                        },
+                        "additionalProperties": true
+                    },
+                    "type": [
+                        "array",
+                        "null"
+                    ]
+                },
                 "infinispan": {
                   "description": "Infinispan cluster configuration",
                   "type": [

--- a/values.schema.json.tpl
+++ b/values.schema.json.tpl
@@ -422,6 +422,39 @@
                         "null"
                     ]
                 },
+                "volumeMounts": {
+                    "description": "Add custome volume mounts to infinispan",
+                    "items": {
+                        "properties": {
+                            "name": {
+                                "type": "string"
+                            },
+                            "mountPath": {
+                                "type": "string"
+                            }
+                        },
+                        "additionalProperties": true
+                    },
+                    "type": [
+                        "array",
+                        "null"
+                    ]
+                },
+                "volumes": {
+                    "description": "Add custome volumes to infinispan",
+                    "items": {
+                        "properties": {
+                            "name": {
+                                "type": "string"
+                            }
+                        },
+                        "additionalProperties": true
+                    },
+                    "type": [
+                        "array",
+                        "null"
+                    ]
+                },
                 "infinispan": {
                   "description": "Infinispan cluster configuration",
                   "type": [

--- a/values.yaml
+++ b/values.yaml
@@ -102,6 +102,14 @@ deploy:
 
   securityContext: {}
 
+  volumeMounts: []
+  #  - name: logs
+  #    mountPath: /logs
+
+  volumes: []
+  #  - name: logs
+  #    emptyDir: {}
+
   ssl:
     endpointSecretName: ""
     transportSecretName: ""


### PR DESCRIPTION
Hi,

As mentioned in https://github.com/infinispan/infinispan-helm-charts/pull/125 here is a way to add custom volumes, which could be used for a dedicated logvolume.

```
deploy:
  volumeMounts:
    - name: logs
      mountPath: /logs
  volumes:
    - name: logs
      emptyDir: {}
```

What do you think of the implementation ?