### PR TITLE
Adding support for creating secrets using certmanager

### DIFF
--- a/.github/workflows/test-chart.yml
+++ b/.github/workflows/test-chart.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Create k8s Kind Cluster
         uses: helm/kind-action@v1
         with:
-          node_image: kindest/node:v1.21.14
+          node_image: kindest/node:v1.25.16
 
       - name: Display cluster settings
         run: |
@@ -44,6 +44,22 @@ jobs:
             kubectl apply -f test/tls_secret.yaml -n helm-test
             kubectl apply -f test/transport_tls_secret.yaml -n helm-test
             helm install example-infinispan . -n helm-test -f values.yaml -f test/tls_values.snippet.yaml --set deploy.replicas=2
+            kubectl -n helm-test rollout status --watch --timeout=300s statefulset/example-infinispan
+            helm uninstall example-infinispan -n helm-test
+            kubectl delete namespace helm-test
+
+      - name: Install cert-manager
+        run: |
+            kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.17.2/cert-manager.yaml
+            kubectl -n cert-manager rollout status --watch --timeout=120s deployment/cert-manager
+            kubectl -n cert-manager rollout status --watch --timeout=120s deployment/cert-manager-webhook
+            kubectl -n cert-manager rollout status --watch --timeout=120s deployment/cert-manager-cainjector
+
+      - name: Testing cert-manager TLS
+        run: |
+            kubectl create namespace helm-test
+            helm install example-infinispan . -n helm-test -f values.yaml -f test/certmanager_tls_values.snippet.yaml --set deploy.replicas=2
+            kubectl -n helm-test wait --for=condition=Ready certificate/example-infinispan-endpoint-cert --timeout=120s
             kubectl -n helm-test rollout status --watch --timeout=300s statefulset/example-infinispan
             helm uninstall example-infinispan -n helm-test
             kubectl delete namespace helm-test

--- a/README.md
+++ b/README.md
@@ -55,6 +55,11 @@ Configure your Infinispan cluster by specifying values in the `deploy.*` section
 | `deploy.securityContext` | Defines the securityContext settings used by the cluster's StatefulSet | `{}` | - |
 | `deploy.ssl.endpointSecretName` | Specifies the name of the secret that contains certificate for endpoint encryption | `""` | - |
 | `deploy.ssl.transportSecretName` | Specifies the name of the secret that contains certificate for transport encryption | `""` | - |
+| `deploy.ssl.certmanager.enabled` | Specifies if cert-manager should be used to issue certificates | `false` | - |
+| `deploy.ssl.certmanager.endpoint.enabled` | Switch to enable cert manager for creating secret endpointSecretName | `false` | - |
+| `deploy.ssl.certmanager.endpoint` | Cert manager specifications, like issueRef, commonName and others | `{}` | - |
+| `deploy.ssl.certmanager.transport.enabled` | Switch to enable cert manager for creating secret transportSecretName | `false` | - |
+| `deploy.ssl.certmanager.transport` | Cert manager specifications, like issueRef, commonName and others | `{}` | - |
 | `deploy.volumeMounts` | Add custome volume mounts to infinispan | `[]` | - |
 | `deploy.volumes` | Add custome volumes to infinispan | `[]` | - |
 | `deploy.infinispan` | Infinispan Server configuration. | - | You should not change the default socket bindings or the security realm and endpoints named "metrics". Modifying these default properties can result in unexpected behavior and loss of service. |

--- a/README.md
+++ b/README.md
@@ -55,11 +55,94 @@ Configure your Infinispan cluster by specifying values in the `deploy.*` section
 | `deploy.securityContext` | Defines the securityContext settings used by the cluster's StatefulSet | `{}` | - |
 | `deploy.ssl.endpointSecretName` | Specifies the name of the secret that contains certificate for endpoint encryption | `""` | - |
 | `deploy.ssl.transportSecretName` | Specifies the name of the secret that contains certificate for transport encryption | `""` | - |
-| `deploy.ssl.certmanager.enabled` | Specifies if cert-manager should be used to issue certificates | `false` | - |
-| `deploy.ssl.certmanager.endpoint.enabled` | Switch to enable cert manager for creating secret endpointSecretName | `false` | - |
-| `deploy.ssl.certmanager.endpoint` | Cert manager specifications, like issueRef, commonName and others | `{}` | - |
-| `deploy.ssl.certmanager.transport.enabled` | Switch to enable cert manager for creating secret transportSecretName | `false` | - |
-| `deploy.ssl.certmanager.transport` | Cert manager specifications, like issueRef, commonName and others | `{}` | - |
+| `deploy.ssl.certmanager.endpoint.enabled` | Enable cert-manager to create the endpoint TLS secret | `false` | Requires cert-manager to be installed. Uses `deploy.ssl.endpointSecretName` as the secret name. |
+| `deploy.ssl.certmanager.endpoint.issuerRef` | Reference to an existing Issuer or ClusterIssuer | - | If omitted, a self-signed Issuer is created automatically. |
+| `deploy.ssl.certmanager.endpoint.keystorePassword` | Password for PKCS12 keystore generation | - | If provided, cert-manager generates a `keystore.p12` in the secret. |
+| `deploy.ssl.certmanager.endpoint.additionalDnsNames` | Additional DNS names to include in the certificate | `[]` | Internal DNS names are computed automatically. |
+| `deploy.ssl.certmanager.transport.enabled` | Enable cert-manager to create the transport TLS secret | `false` | Requires cert-manager to be installed. Uses `deploy.ssl.transportSecretName` as the secret name. |
+| `deploy.ssl.certmanager.transport.issuerRef` | Reference to an existing Issuer or ClusterIssuer | - | If omitted, a self-signed Issuer is created automatically. |
+| `deploy.ssl.certmanager.transport.keystorePassword` | Password for PKCS12 keystore generation | - | If provided, cert-manager generates a `keystore.p12` in the secret. |
+| `deploy.ssl.certmanager.transport.additionalDnsNames` | Additional DNS names to include in the certificate | `[]` | Internal DNS names are computed automatically. |
 | `deploy.volumeMounts` | Add custome volume mounts to infinispan | `[]` | - |
 | `deploy.volumes` | Add custome volumes to infinispan | `[]` | - |
 | `deploy.infinispan` | Infinispan Server configuration. | - | You should not change the default socket bindings or the security realm and endpoints named "metrics". Modifying these default properties can result in unexpected behavior and loss of service. |
+
+## Cert-Manager Integration
+
+This chart can automatically create TLS certificates using [cert-manager](https://cert-manager.io/).
+Cert-manager must be installed in your cluster before enabling this feature.
+
+### Basic Usage
+
+To enable cert-manager for endpoint TLS, set the following values:
+
+```yaml
+deploy:
+  ssl:
+    endpointSecretName: "my-endpoint-cert"
+    certmanager:
+      endpoint:
+        enabled: true
+```
+
+This creates a `Certificate` resource that provisions the secret specified by `endpointSecretName`.
+DNS names for the certificate are computed automatically from the release name, namespace, and cluster domain.
+
+### Custom Issuer
+
+By default, a self-signed `Issuer` is created automatically. To use your own Issuer or ClusterIssuer:
+
+```yaml
+deploy:
+  ssl:
+    certmanager:
+      endpoint:
+        enabled: true
+        issuerRef:
+          name: my-issuer
+          kind: ClusterIssuer
+```
+
+### PKCS12 Keystore
+
+To include a PKCS12 keystore in the generated secret:
+
+```yaml
+deploy:
+  ssl:
+    certmanager:
+      endpoint:
+        enabled: true
+        keystorePassword: "changeit"
+```
+
+### Transport TLS
+
+Transport TLS secures internal cluster communication and can be enabled independently:
+
+```yaml
+deploy:
+  ssl:
+    endpointSecretName: "my-endpoint-cert"
+    transportSecretName: "my-transport-cert"
+    certmanager:
+      endpoint:
+        enabled: true
+      transport:
+        enabled: true
+```
+
+### Additional DNS Names
+
+To add custom DNS names beyond the auto-computed entries:
+
+```yaml
+deploy:
+  ssl:
+    certmanager:
+      endpoint:
+        enabled: true
+        additionalDnsNames:
+          - "custom.example.com"
+          - "*.example.com"
+```

--- a/README.md.tpl
+++ b/README.md.tpl
@@ -55,6 +55,11 @@ Configure your {brandname} cluster by specifying values in the `deploy.*` sectio
 | `deploy.securityContext` | Defines the securityContext settings used by the cluster's StatefulSet | `{}` | - |
 | `deploy.ssl.endpointSecretName` | Specifies the name of the secret that contains certificate for endpoint encryption | `""` | - |
 | `deploy.ssl.transportSecretName` | Specifies the name of the secret that contains certificate for transport encryption | `""` | - |
+| `deploy.ssl.certmanager.enabled` | Specifies if cert-manager should be used to issue certificates | `false` | - |
+| `deploy.ssl.certmanager.endpoint.enabled` | Switch to enable cert manager for creating secret endpointSecretName | `false` | - |
+| `deploy.ssl.certmanager.endpoint` | Cert manager specifications, like issueRef, commonName and others | `{}` | - |
+| `deploy.ssl.certmanager.transport.enabled` | Switch to enable cert manager for creating secret transportSecretName | `false` | - |
+| `deploy.ssl.certmanager.transport` | Cert manager specifications, like issueRef, commonName and others | `{}` | - |
 | `deploy.volumeMounts` | Add custome volume mounts to infinispan | `[]` | - |
 | `deploy.volumes` | Add custome volumes to infinispan | `[]` | - |
 | `deploy.infinispan` | {brandname} Server configuration. | - | You should not change the default socket bindings or the security realm and endpoints named "metrics". Modifying these default properties can result in unexpected behavior and loss of service. |

--- a/README.md.tpl
+++ b/README.md.tpl
@@ -55,11 +55,94 @@ Configure your {brandname} cluster by specifying values in the `deploy.*` sectio
 | `deploy.securityContext` | Defines the securityContext settings used by the cluster's StatefulSet | `{}` | - |
 | `deploy.ssl.endpointSecretName` | Specifies the name of the secret that contains certificate for endpoint encryption | `""` | - |
 | `deploy.ssl.transportSecretName` | Specifies the name of the secret that contains certificate for transport encryption | `""` | - |
-| `deploy.ssl.certmanager.enabled` | Specifies if cert-manager should be used to issue certificates | `false` | - |
-| `deploy.ssl.certmanager.endpoint.enabled` | Switch to enable cert manager for creating secret endpointSecretName | `false` | - |
-| `deploy.ssl.certmanager.endpoint` | Cert manager specifications, like issueRef, commonName and others | `{}` | - |
-| `deploy.ssl.certmanager.transport.enabled` | Switch to enable cert manager for creating secret transportSecretName | `false` | - |
-| `deploy.ssl.certmanager.transport` | Cert manager specifications, like issueRef, commonName and others | `{}` | - |
+| `deploy.ssl.certmanager.endpoint.enabled` | Enable cert-manager to create the endpoint TLS secret | `false` | Requires cert-manager to be installed. Uses `deploy.ssl.endpointSecretName` as the secret name. |
+| `deploy.ssl.certmanager.endpoint.issuerRef` | Reference to an existing Issuer or ClusterIssuer | - | If omitted, a self-signed Issuer is created automatically. |
+| `deploy.ssl.certmanager.endpoint.keystorePassword` | Password for PKCS12 keystore generation | - | If provided, cert-manager generates a `keystore.p12` in the secret. |
+| `deploy.ssl.certmanager.endpoint.additionalDnsNames` | Additional DNS names to include in the certificate | `[]` | Internal DNS names are computed automatically. |
+| `deploy.ssl.certmanager.transport.enabled` | Enable cert-manager to create the transport TLS secret | `false` | Requires cert-manager to be installed. Uses `deploy.ssl.transportSecretName` as the secret name. |
+| `deploy.ssl.certmanager.transport.issuerRef` | Reference to an existing Issuer or ClusterIssuer | - | If omitted, a self-signed Issuer is created automatically. |
+| `deploy.ssl.certmanager.transport.keystorePassword` | Password for PKCS12 keystore generation | - | If provided, cert-manager generates a `keystore.p12` in the secret. |
+| `deploy.ssl.certmanager.transport.additionalDnsNames` | Additional DNS names to include in the certificate | `[]` | Internal DNS names are computed automatically. |
 | `deploy.volumeMounts` | Add custome volume mounts to infinispan | `[]` | - |
 | `deploy.volumes` | Add custome volumes to infinispan | `[]` | - |
 | `deploy.infinispan` | {brandname} Server configuration. | - | You should not change the default socket bindings or the security realm and endpoints named "metrics". Modifying these default properties can result in unexpected behavior and loss of service. |
+
+## Cert-Manager Integration
+
+This chart can automatically create TLS certificates using [cert-manager](https://cert-manager.io/).
+Cert-manager must be installed in your cluster before enabling this feature.
+
+### Basic Usage
+
+To enable cert-manager for endpoint TLS, set the following values:
+
+```yaml
+deploy:
+  ssl:
+    endpointSecretName: "my-endpoint-cert"
+    certmanager:
+      endpoint:
+        enabled: true
+```
+
+This creates a `Certificate` resource that provisions the secret specified by `endpointSecretName`.
+DNS names for the certificate are computed automatically from the release name, namespace, and cluster domain.
+
+### Custom Issuer
+
+By default, a self-signed `Issuer` is created automatically. To use your own Issuer or ClusterIssuer:
+
+```yaml
+deploy:
+  ssl:
+    certmanager:
+      endpoint:
+        enabled: true
+        issuerRef:
+          name: my-issuer
+          kind: ClusterIssuer
+```
+
+### PKCS12 Keystore
+
+To include a PKCS12 keystore in the generated secret:
+
+```yaml
+deploy:
+  ssl:
+    certmanager:
+      endpoint:
+        enabled: true
+        keystorePassword: "changeit"
+```
+
+### Transport TLS
+
+Transport TLS secures internal cluster communication and can be enabled independently:
+
+```yaml
+deploy:
+  ssl:
+    endpointSecretName: "my-endpoint-cert"
+    transportSecretName: "my-transport-cert"
+    certmanager:
+      endpoint:
+        enabled: true
+      transport:
+        enabled: true
+```
+
+### Additional DNS Names
+
+To add custom DNS names beyond the auto-computed entries:
+
+```yaml
+deploy:
+  ssl:
+    certmanager:
+      endpoint:
+        enabled: true
+        additionalDnsNames:
+          - "custom.example.com"
+          - "*.example.com"
+```

--- a/templates/cert-keystore-secret.yaml
+++ b/templates/cert-keystore-secret.yaml
@@ -1,0 +1,30 @@
+{{- $name := include "infinispan-helm-charts.name" . }}
+{{- if and (.Capabilities.APIVersions.Has "cert-manager.io/v1/Certificate") .Values.deploy.ssl.certmanager.endpoint.enabled .Values.deploy.ssl.certmanager.endpoint.keystorePassword }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ printf "%s-endpoint-keystore-password" $name }}
+  annotations:
+    {{- include "infinispan-helm-charts.annotations" . | nindent 4 }}
+  labels:
+    app: infinispan-cert-keystore
+    {{- include "infinispan-helm-charts.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  password: {{ .Values.deploy.ssl.certmanager.endpoint.keystorePassword | quote }}
+{{- end }}
+---
+{{- if and (.Capabilities.APIVersions.Has "cert-manager.io/v1/Certificate") .Values.deploy.ssl.certmanager.transport.enabled .Values.deploy.ssl.certmanager.transport.keystorePassword }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ printf "%s-transport-keystore-password" $name }}
+  annotations:
+    {{- include "infinispan-helm-charts.annotations" . | nindent 4 }}
+  labels:
+    app: infinispan-cert-keystore
+    {{- include "infinispan-helm-charts.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  password: {{ .Values.deploy.ssl.certmanager.transport.keystorePassword | quote }}
+{{- end }}

--- a/templates/certificate-issuer.yaml
+++ b/templates/certificate-issuer.yaml
@@ -1,0 +1,13 @@
+{{- if (.Capabilities.APIVersions.Has "cert-manager.io/v1/Certificate" ) }}
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: selfsigned-issuer
+  annotations:
+    {{- include "infinispan-helm-charts.annotations" . | nindent 4 }}
+  labels:
+    app: infinispan-endpoint-cert
+    {{- include "infinispan-helm-charts.labels" . | nindent 4 }}
+spec:
+  selfSigned: {}
+{{- end }}

--- a/templates/certificate-issuer.yaml
+++ b/templates/certificate-issuer.yaml
@@ -1,13 +1,22 @@
-{{- if (.Capabilities.APIVersions.Has "cert-manager.io/v1/Certificate" ) }}
+{{- if .Capabilities.APIVersions.Has "cert-manager.io/v1/Issuer" }}
+{{- $needsIssuer := false }}
+{{- if and .Values.deploy.ssl.certmanager.endpoint.enabled (not .Values.deploy.ssl.certmanager.endpoint.issuerRef) }}
+  {{- $needsIssuer = true }}
+{{- end }}
+{{- if and .Values.deploy.ssl.certmanager.transport.enabled (not .Values.deploy.ssl.certmanager.transport.issuerRef) }}
+  {{- $needsIssuer = true }}
+{{- end }}
+{{- if $needsIssuer }}
 apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
-  name: selfsigned-issuer
+  name: {{ printf "%s-selfsigned-issuer" (include "infinispan-helm-charts.name" .) }}
   annotations:
     {{- include "infinispan-helm-charts.annotations" . | nindent 4 }}
   labels:
-    app: infinispan-endpoint-cert
+    app: infinispan-cert-issuer
     {{- include "infinispan-helm-charts.labels" . | nindent 4 }}
 spec:
   selfSigned: {}
+{{- end }}
 {{- end }}

--- a/templates/certificate.yaml
+++ b/templates/certificate.yaml
@@ -1,10 +1,15 @@
----
-{{- if and ( .Capabilities.APIVersions.Has "cert-manager.io/v1/Certificate" ) (.Values.deploy.ssl.certmanager.enabled) }}
+{{- $name := include "infinispan-helm-charts.name" . }}
 {{- if .Values.deploy.ssl.certmanager.endpoint.enabled }}
+{{- if not (.Capabilities.APIVersions.Has "cert-manager.io/v1/Certificate") }}
+{{- fail "deploy.ssl.certmanager.endpoint.enabled is true but cert-manager CRDs are not installed in the cluster" }}
+{{- end }}
+{{- if not .Values.deploy.ssl.endpointSecretName }}
+{{- fail "deploy.ssl.endpointSecretName must be set when certmanager.endpoint is enabled" }}
+{{- end }}
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
-  name: {{ printf "%s-endpoint-cert" (include "infinispan-helm-charts.name" .) }}
+  name: {{ printf "%s-endpoint-cert" $name }}
   annotations:
     {{- include "infinispan-helm-charts.annotations" . | nindent 4 }}
   labels:
@@ -12,24 +17,47 @@ metadata:
     {{- include "infinispan-helm-charts.labels" . | nindent 4 }}
 spec:
   secretName: {{ .Values.deploy.ssl.endpointSecretName }}
-  commonName: infinispan
+  commonName: {{ $name }}
   dnsNames:
-    - infinispan
-    - infinispan.{{ .Release.Namespace }}
-    - {{ printf "%s-ping.%s.svc.%s" (include "infinispan-helm-charts.name" .) .Release.Namespace .Values.deploy.clusterDomain }}
-    - infinispan.{{ .Release.Namespace }}.{{ .Values.deploy.clusterDomain }}
-  issuerRef:
-    {{- with $_ := .Values.deploy.ssl.certmanager.issuerRef }}
+    - {{ $name }}
+    - {{ printf "%s.%s" $name .Release.Namespace }}
+    - {{ printf "%s.%s.svc.%s" $name .Release.Namespace .Values.deploy.clusterDomain }}
+    - {{ printf "%s-ping.%s.svc.%s" $name .Release.Namespace .Values.deploy.clusterDomain }}
+    {{- if .Values.deploy.expose.host }}
+    - {{ .Values.deploy.expose.host | quote }}
+    {{- end }}
+    {{- with .Values.deploy.ssl.certmanager.endpoint.additionalDnsNames }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
+  {{- if .Values.deploy.ssl.certmanager.endpoint.issuerRef }}
+  issuerRef:
+    {{- toYaml .Values.deploy.ssl.certmanager.endpoint.issuerRef | nindent 4 }}
+  {{- else }}
+  issuerRef:
+    name: {{ printf "%s-selfsigned-issuer" $name }}
+    kind: Issuer
+  {{- end }}
+  {{- if .Values.deploy.ssl.certmanager.endpoint.keystorePassword }}
+  keystores:
+    pkcs12:
+      create: true
+      passwordSecretRef:
+        name: {{ printf "%s-endpoint-keystore-password" $name }}
+        key: password
+  {{- end }}
 {{- end }}
-
 ---
 {{- if .Values.deploy.ssl.certmanager.transport.enabled }}
+{{- if not (.Capabilities.APIVersions.Has "cert-manager.io/v1/Certificate") }}
+{{- fail "deploy.ssl.certmanager.transport.enabled is true but cert-manager CRDs are not installed in the cluster" }}
+{{- end }}
+{{- if not .Values.deploy.ssl.transportSecretName }}
+{{- fail "deploy.ssl.transportSecretName must be set when certmanager.transport is enabled" }}
+{{- end }}
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
-  name: {{ printf "%s-transport-cert" (include "infinispan-helm-charts.name" .) }}
+  name: {{ printf "%s-transport-cert" $name }}
   annotations:
     {{- include "infinispan-helm-charts.annotations" . | nindent 4 }}
   labels:
@@ -37,15 +65,29 @@ metadata:
     {{- include "infinispan-helm-charts.labels" . | nindent 4 }}
 spec:
   secretName: {{ .Values.deploy.ssl.transportSecretName }}
-  commonName: infinispan
+  commonName: {{ $name }}
   dnsNames:
-    - infinispan
-    - infinispan.{{ .Release.Namespace }}
-    - {{ printf "%s-ping.%s.svc.%s" (include "infinispan-helm-charts.name" .) .Release.Namespace .Values.deploy.clusterDomain }}
-    - infinispan.{{ .Release.Namespace }}.{{ .Values.deploy.clusterDomain }}
-  issuerRef:
-    {{- with $_ := .Values.deploy.ssl.certmanager.issuerRef }}
+    - {{ $name }}
+    - {{ printf "%s.%s" $name .Release.Namespace }}
+    - {{ printf "%s.%s.svc.%s" $name .Release.Namespace .Values.deploy.clusterDomain }}
+    - {{ printf "%s-ping.%s.svc.%s" $name .Release.Namespace .Values.deploy.clusterDomain }}
+    {{- with .Values.deploy.ssl.certmanager.transport.additionalDnsNames }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
-{{- end }}
+  {{- if .Values.deploy.ssl.certmanager.transport.issuerRef }}
+  issuerRef:
+    {{- toYaml .Values.deploy.ssl.certmanager.transport.issuerRef | nindent 4 }}
+  {{- else }}
+  issuerRef:
+    name: {{ printf "%s-selfsigned-issuer" $name }}
+    kind: Issuer
+  {{- end }}
+  {{- if .Values.deploy.ssl.certmanager.transport.keystorePassword }}
+  keystores:
+    pkcs12:
+      create: true
+      passwordSecretRef:
+        name: {{ printf "%s-transport-keystore-password" $name }}
+        key: password
+  {{- end }}
 {{- end }}

--- a/templates/certificate.yaml
+++ b/templates/certificate.yaml
@@ -1,0 +1,51 @@
+---
+{{- if and ( .Capabilities.APIVersions.Has "cert-manager.io/v1/Certificate" ) (.Values.deploy.ssl.certmanager.enabled) }}
+{{- if .Values.deploy.ssl.certmanager.endpoint.enabled }}
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ printf "%s-endpoint-cert" (include "infinispan-helm-charts.name" .) }}
+  annotations:
+    {{- include "infinispan-helm-charts.annotations" . | nindent 4 }}
+  labels:
+    app: infinispan-endpoint-cert
+    {{- include "infinispan-helm-charts.labels" . | nindent 4 }}
+spec:
+  secretName: {{ .Values.deploy.ssl.endpointSecretName }}
+  commonName: infinispan
+  dnsNames:
+    - infinispan
+    - infinispan.{{ .Release.Namespace }}
+    - {{ printf "%s-ping.%s.svc.%s" (include "infinispan-helm-charts.name" .) .Release.Namespace .Values.deploy.clusterDomain }}
+    - infinispan.{{ .Release.Namespace }}.{{ .Values.deploy.clusterDomain }}
+  issuerRef:
+    {{- with $_ := .Values.deploy.ssl.certmanager.issuerRef }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+{{- end }}
+
+---
+{{- if .Values.deploy.ssl.certmanager.transport.enabled }}
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ printf "%s-transport-cert" (include "infinispan-helm-charts.name" .) }}
+  annotations:
+    {{- include "infinispan-helm-charts.annotations" . | nindent 4 }}
+  labels:
+    app: infinispan-transport-cert
+    {{- include "infinispan-helm-charts.labels" . | nindent 4 }}
+spec:
+  secretName: {{ .Values.deploy.ssl.transportSecretName }}
+  commonName: infinispan
+  dnsNames:
+    - infinispan
+    - infinispan.{{ .Release.Namespace }}
+    - {{ printf "%s-ping.%s.svc.%s" (include "infinispan-helm-charts.name" .) .Release.Namespace .Values.deploy.clusterDomain }}
+    - infinispan.{{ .Release.Namespace }}.{{ .Values.deploy.clusterDomain }}
+  issuerRef:
+    {{- with $_ := .Values.deploy.ssl.certmanager.issuerRef }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+{{- end }}
+{{- end }}

--- a/templates/statefulset.yaml
+++ b/templates/statefulset.yaml
@@ -203,4 +203,7 @@ spec:
         resources:
           requests:
             storage: {{ .Values.deploy.container.storage.size }}
+    {{- with .Values.deploy.volumeClaimTemplates }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   {{- end }}

--- a/templates/statefulset.yaml
+++ b/templates/statefulset.yaml
@@ -203,7 +203,4 @@ spec:
         resources:
           requests:
             storage: {{ .Values.deploy.container.storage.size }}
-    {{- with .Values.deploy.volumeClaimTemplates }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
   {{- end }}

--- a/test/certmanager_tls_values.snippet.yaml
+++ b/test/certmanager_tls_values.snippet.yaml
@@ -1,0 +1,46 @@
+deploy:
+  security:
+    batch: |-
+      credentials add keystore -c changeit -p secret --path="internal-credentials.pfx"
+  ssl:
+    endpointSecretName: "endpoint-cert-tls"
+    certmanager:
+      endpoint:
+        enabled: true
+        keystorePassword: "changeit"
+  infinispan:
+    cacheContainer:
+      transport:
+         stack: "kubernetes"
+    server:
+      security:
+        credentialStores:
+          - name: credentials
+            path: internal-credentials.pfx
+            clearTextCredential:
+              clearText: "secret"
+        securityRealms:
+        - name: default
+          propertiesRealm:
+            groupProperties:
+              path: groups.properties
+            groupsAttribute: Roles
+            userProperties:
+              path: users.properties
+          serverIdentities:
+            ssl:
+              keystore:
+                alias: "1"
+                path: "/etc/encrypt/endpoint/keystore.p12"
+                credentialReference:
+                  store: credentials
+                  alias: keystore
+        - name: metrics
+          propertiesRealm:
+            groupProperties:
+              path: metrics-groups.properties
+              relativeTo: infinispan.server.config.path
+            groupsAttribute: Roles
+            userProperties:
+              path: metrics-users.properties
+              relativeTo: infinispan.server.config.path

--- a/values.schema.json
+++ b/values.schema.json
@@ -203,6 +203,44 @@
                               "string",
                               "null"
                           ]
+                      },
+                      "transportSecretName": {
+                          "description": "Specifies the name of a secret that contains TLS certificate",
+                          "type": [
+                              "string",
+                              "null"
+                          ]
+                      },
+                      "certmanager": {
+                          "type": "object",
+                          "properties": {
+                            "enabled": {
+                                "description": "Specifies the name of a secret that contains TLS certificate",
+                                "type": "boolean"
+                            },
+                            "endpoint": {
+                                "description": "Cert manager sepc",
+                                "type": "object",
+                                "properties": {
+                                    "enabled": {
+                                        "description": "Specify if certmanager should create the secret",
+                                        "type": "boolean"
+                                    }
+                                },
+                                "additionalProperties": true
+                            },
+                            "transport": {
+                                "description": "Cert manager spec",
+                                "type": "object",
+                                "properties": {
+                                    "enabled": {
+                                        "description": "Specifies if certmanager should create the secret",
+                                        "type": "boolean"
+                                    }
+                                },
+                                "additionalProperties": true
+                            }
+                          }
                       }
                      }
                   },

--- a/values.schema.json
+++ b/values.schema.json
@@ -197,48 +197,73 @@
                   "endpointSecretName"
                   ],
                   "properties": {
-                      "endPointSecretName": {
-                          "description": "Specifies the name of a secret that contains TLS certificate",
+                      "endpointSecretName": {
+                          "description": "Specifies the name of the secret that contains the TLS certificate for endpoint encryption",
                           "type": [
                               "string",
                               "null"
                           ]
                       },
                       "transportSecretName": {
-                          "description": "Specifies the name of a secret that contains TLS certificate",
+                          "description": "Specifies the name of the secret that contains the TLS certificate for transport encryption",
                           "type": [
                               "string",
                               "null"
                           ]
                       },
                       "certmanager": {
+                          "description": "cert-manager integration for automatic TLS certificate issuing",
                           "type": "object",
                           "properties": {
-                            "enabled": {
-                                "description": "Specifies the name of a secret that contains TLS certificate",
-                                "type": "boolean"
-                            },
                             "endpoint": {
-                                "description": "Cert manager sepc",
+                                "description": "cert-manager configuration for the endpoint certificate",
                                 "type": "object",
                                 "properties": {
                                     "enabled": {
-                                        "description": "Specify if certmanager should create the secret",
+                                        "description": "Enable cert-manager to create the endpoint TLS secret",
                                         "type": "boolean"
+                                    },
+                                    "issuerRef": {
+                                        "description": "Reference to an existing Issuer or ClusterIssuer. If omitted, a self-signed Issuer is created",
+                                        "type": "object"
+                                    },
+                                    "keystorePassword": {
+                                        "description": "Password for PKCS12 keystore. If provided, cert-manager generates a keystore.p12 in the secret",
+                                        "type": "string"
+                                    },
+                                    "additionalDnsNames": {
+                                        "description": "Additional DNS names to include in the certificate",
+                                        "type": "array",
+                                        "items": {
+                                            "type": "string"
+                                        }
                                     }
-                                },
-                                "additionalProperties": true
+                                }
                             },
                             "transport": {
-                                "description": "Cert manager spec",
+                                "description": "cert-manager configuration for the transport certificate",
                                 "type": "object",
                                 "properties": {
                                     "enabled": {
-                                        "description": "Specifies if certmanager should create the secret",
+                                        "description": "Enable cert-manager to create the transport TLS secret",
                                         "type": "boolean"
+                                    },
+                                    "issuerRef": {
+                                        "description": "Reference to an existing Issuer or ClusterIssuer. If omitted, a self-signed Issuer is created",
+                                        "type": "object"
+                                    },
+                                    "keystorePassword": {
+                                        "description": "Password for PKCS12 keystore. If provided, cert-manager generates a keystore.p12 in the secret",
+                                        "type": "string"
+                                    },
+                                    "additionalDnsNames": {
+                                        "description": "Additional DNS names to include in the certificate",
+                                        "type": "array",
+                                        "items": {
+                                            "type": "string"
+                                        }
                                     }
-                                },
-                                "additionalProperties": true
+                                }
                             }
                           }
                       }

--- a/values.schema.json.tpl
+++ b/values.schema.json.tpl
@@ -203,6 +203,44 @@
                               "string",
                               "null"
                           ]
+                      },
+                      "transportSecretName": {
+                          "description": "Specifies the name of a secret that contains TLS certificate",
+                          "type": [
+                              "string",
+                              "null"
+                          ]
+                      },
+                      "certmanager": {
+                          "type": "object",
+                          "properties": {
+                            "enabled": {
+                                "description": "Specifies the name of a secret that contains TLS certificate",
+                                "type": "boolean"
+                            },
+                            "endpoint": {
+                                "description": "Cert manager sepc",
+                                "type": "object",
+                                "properties": {
+                                    "enabled": {
+                                        "description": "Specify if certmanager should create the secret",
+                                        "type": "boolean"
+                                    }
+                                },
+                                "additionalProperties": true
+                            },
+                            "transport": {
+                                "description": "Cert manager spec",
+                                "type": "object",
+                                "properties": {
+                                    "enabled": {
+                                        "description": "Specifies if certmanager should create the secret",
+                                        "type": "boolean"
+                                    }
+                                },
+                                "additionalProperties": true
+                            }
+                          }
                       }
                      }
                   },

--- a/values.schema.json.tpl
+++ b/values.schema.json.tpl
@@ -197,48 +197,73 @@
                   "endpointSecretName"
                   ],
                   "properties": {
-                      "endPointSecretName": {
-                          "description": "Specifies the name of a secret that contains TLS certificate",
+                      "endpointSecretName": {
+                          "description": "Specifies the name of the secret that contains the TLS certificate for endpoint encryption",
                           "type": [
                               "string",
                               "null"
                           ]
                       },
                       "transportSecretName": {
-                          "description": "Specifies the name of a secret that contains TLS certificate",
+                          "description": "Specifies the name of the secret that contains the TLS certificate for transport encryption",
                           "type": [
                               "string",
                               "null"
                           ]
                       },
                       "certmanager": {
+                          "description": "cert-manager integration for automatic TLS certificate issuing",
                           "type": "object",
                           "properties": {
-                            "enabled": {
-                                "description": "Specifies the name of a secret that contains TLS certificate",
-                                "type": "boolean"
-                            },
                             "endpoint": {
-                                "description": "Cert manager sepc",
+                                "description": "cert-manager configuration for the endpoint certificate",
                                 "type": "object",
                                 "properties": {
                                     "enabled": {
-                                        "description": "Specify if certmanager should create the secret",
+                                        "description": "Enable cert-manager to create the endpoint TLS secret",
                                         "type": "boolean"
+                                    },
+                                    "issuerRef": {
+                                        "description": "Reference to an existing Issuer or ClusterIssuer. If omitted, a self-signed Issuer is created",
+                                        "type": "object"
+                                    },
+                                    "keystorePassword": {
+                                        "description": "Password for PKCS12 keystore. If provided, cert-manager generates a keystore.p12 in the secret",
+                                        "type": "string"
+                                    },
+                                    "additionalDnsNames": {
+                                        "description": "Additional DNS names to include in the certificate",
+                                        "type": "array",
+                                        "items": {
+                                            "type": "string"
+                                        }
                                     }
-                                },
-                                "additionalProperties": true
+                                }
                             },
                             "transport": {
-                                "description": "Cert manager spec",
+                                "description": "cert-manager configuration for the transport certificate",
                                 "type": "object",
                                 "properties": {
                                     "enabled": {
-                                        "description": "Specifies if certmanager should create the secret",
+                                        "description": "Enable cert-manager to create the transport TLS secret",
                                         "type": "boolean"
+                                    },
+                                    "issuerRef": {
+                                        "description": "Reference to an existing Issuer or ClusterIssuer. If omitted, a self-signed Issuer is created",
+                                        "type": "object"
+                                    },
+                                    "keystorePassword": {
+                                        "description": "Password for PKCS12 keystore. If provided, cert-manager generates a keystore.p12 in the secret",
+                                        "type": "string"
+                                    },
+                                    "additionalDnsNames": {
+                                        "description": "Additional DNS names to include in the certificate",
+                                        "type": "array",
+                                        "items": {
+                                            "type": "string"
+                                        }
                                     }
-                                },
-                                "additionalProperties": true
+                                }
                             }
                           }
                       }

--- a/values.yaml
+++ b/values.yaml
@@ -122,6 +122,17 @@ deploy:
   ssl:
     endpointSecretName: ""
     transportSecretName: ""
+    certmanager:
+      enabled: false
+      endpoint:
+        enabled: false
+        # docs https://cert-manager.io/docs/usage/certificate/
+        #issuerRef:
+        #  name: selfsigned
+        #  kind: ClusterIssuer
+        # commonName: 'example-infinispan'
+      transport:
+        enabled: false
 
   infinispan:
     cacheContainer:

--- a/values.yaml
+++ b/values.yaml
@@ -122,15 +122,20 @@ deploy:
   ssl:
     endpointSecretName: ""
     transportSecretName: ""
+    # [USER] Use cert-manager to automatically issue TLS certificates.
+    # Requires cert-manager to be installed in the cluster.
     certmanager:
-      enabled: false
       endpoint:
         enabled: false
-        # docs https://cert-manager.io/docs/usage/certificate/
-        #issuerRef:
-        #  name: selfsigned
-        #  kind: ClusterIssuer
-        # commonName: 'example-infinispan'
+        # [USER] Provide an issuerRef to use your own Issuer/ClusterIssuer.
+        # If omitted, a self-signed Issuer is created automatically.
+        # issuerRef:
+        #   name: my-issuer
+        #   kind: ClusterIssuer
+        # [USER] Provide a password to include a PKCS12 keystore in the secret.
+        # keystorePassword: "changeit"
+        # [USER] Additional DNS names to include in the certificate.
+        # additionalDnsNames: []
       transport:
         enabled: false
 


### PR DESCRIPTION
Hi,

A PR, which is a proposal that might require a bit of discussion and corrections.

I suggest to support that cert-manager create the secrets for deploy.ssl.endpointSecretName and transportSecretName.

A configuation could look like this
```
deploy:
  ssl:
    endpointSecretName: "test-certificate"
    transportSecretName: ""
    certmanager:
      enabled: true
      endpoint:
        enabled: true
        commonName: 'example-infinispan'
      transport:
        enabled: false
```

This will create the secret "test-certificate" by use of cert-manager, this example will not create a secret for transport.