### PR TITLE
fix: prevent b64dec on nil password and ensure secret lookup safety

### DIFF
--- a/templates/secret.yaml
+++ b/templates/secret.yaml
@@ -1,9 +1,12 @@
 {{- if not .Values.deploy.security.secretName }}
-  {{- $secretName := (include "infinispan-helm-charts.secret" .)}}
-  {{- $password :=  (randAlphaNum 8 ) }}
+  {{- $secretName := (include "infinispan-helm-charts.secret" .) }}
+  {{- $password := randAlphaNum 8 }}
   {{- if .Release.IsUpgrade }}
-    {{- $secretData := (get ((lookup "v1" "Secret" .Release.Namespace  $secretName ) | default dict) "data")}}
-    {{- $password = (get $secretData "password" | b64dec ) | default (randAlphaNum 8 ) }}
+    {{- with lookup "v1" "Secret" .Release.Namespace $secretName }}
+      {{- if and .data (hasKey .data "password") }}
+        {{- $password = .data.password | b64dec }}
+      {{- end }}
+    {{- end }}
   {{- end }}
 apiVersion: v1
 kind: Secret


### PR DESCRIPTION
This PR fixes a bug in the template that occurs when upgrading a Helm release. 
The issue may affects charts that import this chart as a dependency. 
During an upgrade, if the default-generated secret is missing, the upgrade fails due to an incorrect type being assigned to secretData.

## Reproduction Steps

```
helm upgrade --install infinispan . --namespace infinispan --create-namespace --debug
kubectl --namespace infinispan delete secret infinispan-generated-secret
helm upgrade --install infinispan . --namespace infinispan --create-namespace --debug
```

Error
```
executing "infinispan/templates/secret.yaml" at <$secretData>: wrong type for value; expected map[string]interface {}; got string
```