### PR TITLE
Add `usePrefixedLabels` configuration for customizable selector label…

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Configure your Infinispan cluster by specifying values in the `deploy.*` section
 | `deploy.logging.console.json` | Outputs logs as JSON on stdout instead of the default colored text format. Useful for log aggregation pipelines (ELK, Loki, etc.). Each log line includes `time`, `service`, `namespace`, and `pod` fields. | `false` | The `POD_NAME` and `POD_NAMESPACE` environment variables are automatically injected via the Downward API and used to populate the `pod` and `namespace` fields. |
 | `deploy.logging.categories` | Configures Infinispan cluster log categories and levels. | `{}` | - |
 | `deploy.podAnnotations` | Adds annotations to each Infinispan pod that you create. | `{}` | - |
-| `deploy.podLabels` | Adds labels to each Infinispan pod that you create. | `{}` | The keys `app`, `clusterName`, `infinispan_app` and `infinispan_clusterName` are reserved for internal selector labels and are ignored if provided. |
+| `deploy.podLabels` | Adds labels to each Infinispan pod that you create. | `{}` | When `deploy.usePrefixedLabels` is `false`, the keys `app` and `clusterName` are reserved and ignored. When `true`, the keys `infinispan_app` and `infinispan_clusterName` are reserved and ignored. |
 | `deploy.svcLabels` | Adds labels to each service that you create.| `{}` | - |
 | `deploy.resourceLabels` | Adds labels to all Infinispan resources including pods and services. | `{}` | - |
 | `deploy.tolerations` | Node taints to tolerate | `[]` | - |

--- a/README.md
+++ b/README.md
@@ -40,17 +40,18 @@ Configure your Infinispan cluster by specifying values in the `deploy.*` section
 | `deploy.logging.console.json` | Outputs logs as JSON on stdout instead of the default colored text format. Useful for log aggregation pipelines (ELK, Loki, etc.). Each log line includes `time`, `service`, `namespace`, and `pod` fields. | `false` | The `POD_NAME` and `POD_NAMESPACE` environment variables are automatically injected via the Downward API and used to populate the `pod` and `namespace` fields. |
 | `deploy.logging.categories` | Configures Infinispan cluster log categories and levels. | `{}` | - |
 | `deploy.podAnnotations` | Adds annotations to each Infinispan pod that you create. | `{}` | - |
-| `deploy.podLabels` | Adds labels to each Infinispan pod that you create. | `{}` | - |
+| `deploy.podLabels` | Adds labels to each Infinispan pod that you create. | `{}` | The keys `app`, `clusterName`, `infinispan_app` and `infinispan_clusterName` are reserved for internal selector labels and are ignored if provided. |
 | `deploy.svcLabels` | Adds labels to each service that you create.| `{}` | - |
 | `deploy.resourceLabels` | Adds labels to all Infinispan resources including pods and services. | `{}` | - |
 | `deploy.tolerations` | Node taints to tolerate | `[]` | - |
 | `deploy.nodeSelector` | Defines the nodeSelector policy used by the cluster's StatefulSet | `{}` | - |
 | `deploy.nodeAffinity` | Defines the nodeAffinity policy used by the cluster's StatefulSet | `{}` | - |
 | `deploy.podAffinity` | Defines the podAffinity policy used by the cluster's StatefulSet | `{}` | - |
-| `deploy.podAntiAffinity` | Defines the podAntiAffinity policy used by the cluster's StatefulSet | <pre><code>podAntiAffinity: ><br>preferredDuringSchedulingIgnoredDuringExecution:<br>      - podAffinityTerm:<br>          labelSelector:<br>            matchLabels:<br>              clusterName: {{ include "infinispan-helm-charts.name" . }}<br>              app: infinispan-pod<br>          topologyKey: kubernetes.io/hostname<br>        weight: 100</code></pre> | - |
+| `deploy.podAntiAffinity` | Defines the podAntiAffinity policy used by the cluster's StatefulSet | <pre><code>podAntiAffinity: ><br>preferredDuringSchedulingIgnoredDuringExecution:<br>      - podAffinityTerm:<br>          labelSelector:<br>            matchLabels:<br>              clusterName: {{ include "infinispan-helm-charts.name" . }}<br>              app: infinispan-pod<br>          topologyKey: kubernetes.io/hostname<br>        weight: 100</code></pre> | Default selector labels in this rule automatically reflect the value of `deploy.usePrefixedLabels`. |
 | `deploy.makeDataDirWritable` | Allows write access to the `data` directory for each Infinispan Server node. | false | Setting the value to `true` creates an initContainer that runs `chmod -R` on the `/opt/infinispan/server/data` directory and changes its permissions. |
 | `deploy.monitoring.enabled` | Enable or disable `ServiceMonitor` functionality. | false | Users must have `monitoring-edit` role assigned by the admin to deploy the Helm chart with `ServiceMonitor` enabled. |
 | `deploy.nameOverride` | Specifies a name for all Infinispan cluster resources. | Helm Chart release name | Configure a name for the created resources only if you need it to be different to the Helm Chart release name. |
+| `deploy.usePrefixedLabels` | Use project-specific prefixed keys for internal selector labels to avoid collisions with admission controllers (e.g. Kyverno). | `false` | When `false`, selector labels use `app` and `clusterName`. When `true`, they use `infinispan_app` and `infinispan_clusterName`. Changing this value on an existing cluster requires deleting and recreating the StatefulSet due to the immutability of the `selector` field. |
 | `deploy.securityContext` | Defines the securityContext settings used by the cluster's StatefulSet | `{}` | - |
 | `deploy.ssl.endpointSecretName` | Specifies the name of the secret that contains certificate for endpoint encryption | `""` | - |
 | `deploy.ssl.transportSecretName` | Specifies the name of the secret that contains certificate for transport encryption | `""` | - |

--- a/README.md.tpl
+++ b/README.md.tpl
@@ -40,7 +40,7 @@ Configure your {brandname} cluster by specifying values in the `deploy.*` sectio
 | `deploy.logging.console.json` | Outputs logs as JSON on stdout instead of the default colored text format. Useful for log aggregation pipelines (ELK, Loki, etc.). Each log line includes `time`, `service`, `namespace`, and `pod` fields. | `false` | The `POD_NAME` and `POD_NAMESPACE` environment variables are automatically injected via the Downward API and used to populate the `pod` and `namespace` fields. |
 | `deploy.logging.categories` | Configures {brandname} cluster log categories and levels. | `{}` | - |
 | `deploy.podAnnotations` | Adds annotations to each Infinispan pod that you create. | `{}` | - |
-| `deploy.podLabels` | Adds labels to each Infinispan pod that you create. | `{}` | The keys `app`, `clusterName`, `infinispan_app` and `infinispan_clusterName` are reserved for internal selector labels and are ignored if provided. |
+| `deploy.podLabels` | Adds labels to each Infinispan pod that you create. | `{}` | When `deploy.usePrefixedLabels` is `false`, the keys `app` and `clusterName` are reserved and ignored. When `true`, the keys `infinispan_app` and `infinispan_clusterName` are reserved and ignored. |
 | `deploy.svcLabels` | Adds labels to each service that you create.| `{}` | - |
 | `deploy.resourceLabels` | Adds labels to all {brandname} resources including pods and services. | `{}` | - |
 | `deploy.tolerations` | Node taints to tolerate | `[]` | - |

--- a/README.md.tpl
+++ b/README.md.tpl
@@ -40,17 +40,18 @@ Configure your {brandname} cluster by specifying values in the `deploy.*` sectio
 | `deploy.logging.console.json` | Outputs logs as JSON on stdout instead of the default colored text format. Useful for log aggregation pipelines (ELK, Loki, etc.). Each log line includes `time`, `service`, `namespace`, and `pod` fields. | `false` | The `POD_NAME` and `POD_NAMESPACE` environment variables are automatically injected via the Downward API and used to populate the `pod` and `namespace` fields. |
 | `deploy.logging.categories` | Configures {brandname} cluster log categories and levels. | `{}` | - |
 | `deploy.podAnnotations` | Adds annotations to each Infinispan pod that you create. | `{}` | - |
-| `deploy.podLabels` | Adds labels to each Infinispan pod that you create. | `{}` | - |
+| `deploy.podLabels` | Adds labels to each Infinispan pod that you create. | `{}` | The keys `app`, `clusterName`, `infinispan_app` and `infinispan_clusterName` are reserved for internal selector labels and are ignored if provided. |
 | `deploy.svcLabels` | Adds labels to each service that you create.| `{}` | - |
 | `deploy.resourceLabels` | Adds labels to all {brandname} resources including pods and services. | `{}` | - |
 | `deploy.tolerations` | Node taints to tolerate | `[]` | - |
 | `deploy.nodeSelector` | Defines the nodeSelector policy used by the cluster's StatefulSet | `{}` | - |
 | `deploy.nodeAffinity` | Defines the nodeAffinity policy used by the cluster's StatefulSet | `{}` | - |
 | `deploy.podAffinity` | Defines the podAffinity policy used by the cluster's StatefulSet | `{}` | - |
-| `deploy.podAntiAffinity` | Defines the podAntiAffinity policy used by the cluster's StatefulSet | <pre><code>podAntiAffinity: ><br>preferredDuringSchedulingIgnoredDuringExecution:<br>      - podAffinityTerm:<br>          labelSelector:<br>            matchLabels:<br>              clusterName: {{ include "infinispan-helm-charts.name" . }}<br>              app: infinispan-pod<br>          topologyKey: kubernetes.io/hostname<br>        weight: 100</code></pre> | - |
+| `deploy.podAntiAffinity` | Defines the podAntiAffinity policy used by the cluster's StatefulSet | <pre><code>podAntiAffinity: ><br>preferredDuringSchedulingIgnoredDuringExecution:<br>      - podAffinityTerm:<br>          labelSelector:<br>            matchLabels:<br>              clusterName: {{ include "infinispan-helm-charts.name" . }}<br>              app: infinispan-pod<br>          topologyKey: kubernetes.io/hostname<br>        weight: 100</code></pre> | Default selector labels in this rule automatically reflect the value of `deploy.usePrefixedLabels`. |
 | `deploy.makeDataDirWritable` | Allows write access to the `data` directory for each {brandname} Server node. | false | Setting the value to `true` creates an initContainer that runs `chmod -R` on the `/opt/infinispan/server/data` directory and changes its permissions. |
 | `deploy.monitoring.enabled` | Enable or disable `ServiceMonitor` functionality. | false | Users must have `monitoring-edit` role assigned by the admin to deploy the Helm chart with `ServiceMonitor` enabled. |
 | `deploy.nameOverride` | Specifies a name for all {brandname} cluster resources. | Helm Chart release name | Configure a name for the created resources only if you need it to be different to the Helm Chart release name. |
+| `deploy.usePrefixedLabels` | Use project-specific prefixed keys for internal selector labels to avoid collisions with admission controllers (e.g. Kyverno). | `false` | When `false`, selector labels use `app` and `clusterName`. When `true`, they use `infinispan_app` and `infinispan_clusterName`. Changing this value on an existing cluster requires deleting and recreating the StatefulSet due to the immutability of the `selector` field. |
 | `deploy.securityContext` | Defines the securityContext settings used by the cluster's StatefulSet | `{}` | - |
 | `deploy.ssl.endpointSecretName` | Specifies the name of the secret that contains certificate for endpoint encryption | `""` | - |
 | `deploy.ssl.transportSecretName` | Specifies the name of the secret that contains certificate for transport encryption | `""` | - |

--- a/documentation/asciidoc/topics/ref_deployment_configuration_values.adoc
+++ b/documentation/asciidoc/topics/ref_deployment_configuration_values.adoc
@@ -99,7 +99,7 @@ The `POD_NAME` and `POD_NAMESPACE` environment variables are automatically injec
 
 |`deploy.podLabels`
 | Adds labels to each {brandname} pod that you create.
-| No default value. The keys `app`, `clusterName`, `infinispan_app` and `infinispan_clusterName` are reserved for internal selector labels and are ignored if provided.
+| No default value. When `deploy.usePrefixedLabels` is `false`, the keys `app` and `clusterName` are reserved and ignored. When `true`, the keys `infinispan_app` and `infinispan_clusterName` are reserved and ignored.
 
 |`deploy.svcLabels`
 | Adds labels to each service that you create.

--- a/documentation/asciidoc/topics/ref_deployment_configuration_values.adoc
+++ b/documentation/asciidoc/topics/ref_deployment_configuration_values.adoc
@@ -99,7 +99,7 @@ The `POD_NAME` and `POD_NAMESPACE` environment variables are automatically injec
 
 |`deploy.podLabels`
 | Adds labels to each {brandname} pod that you create.
-| No default value.
+| No default value. The keys `app`, `clusterName`, `infinispan_app` and `infinispan_clusterName` are reserved for internal selector labels and are ignored if provided.
 
 |`deploy.svcLabels`
 | Adds labels to each service that you create.
@@ -108,6 +108,12 @@ The `POD_NAME` and `POD_NAMESPACE` environment variables are automatically injec
 |`deploy.resourceLabels`
 |Adds labels to all {brandname} resources including pods and services.
 |No default value.
+
+|`deploy.usePrefixedLabels`
+|Use project-specific prefixed keys for internal selector labels to avoid collisions with admission controllers (e.g. Kyverno).
+When `false`, selector labels use `app` and `clusterName`. When `true`, they use `infinispan_app` and `infinispan_clusterName`.
+Changing this value on an existing cluster requires deleting and recreating the StatefulSet due to the immutability of the `selector` field.
+|`false`
 
 |`deploy.makeDataDirWritable`
 |Allows write access to the `data` directory for each {brandname} Server node. |`false`

--- a/templates/helpers.tpl
+++ b/templates/helpers.tpl
@@ -57,8 +57,14 @@ Pod custom labels
 
 {{- define "infinispan-helm-charts.podLabels" -}}
 {{- range .Values.deploy.podLabels }}
-{{- if and (ne .key "clusterName") (ne .key "app") (ne .key "infinispan_clusterName") (ne .key "infinispan_app") }}
+{{- if $.Values.deploy.usePrefixedLabels }}
+{{- if and (ne .key "infinispan_clusterName") (ne .key "infinispan_app") }}
 {{ .key }}: {{ .value | quote }}
+{{- end }}
+{{- else }}
+{{- if and (ne .key "clusterName") (ne .key "app") }}
+{{ .key }}: {{ .value | quote }}
+{{- end }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/templates/helpers.tpl
+++ b/templates/helpers.tpl
@@ -57,7 +57,7 @@ Pod custom labels
 
 {{- define "infinispan-helm-charts.podLabels" -}}
 {{- range .Values.deploy.podLabels }}
-{{- if and (ne .key "clusterName") (ne .key "app") }}
+{{- if and (ne .key "clusterName") (ne .key "app") (ne .key "infinispan_clusterName") (ne .key "infinispan_app") }}
 {{ .key }}: {{ .value | quote }}
 {{- end }}
 {{- end }}
@@ -77,8 +77,13 @@ Service custom labels
 Service selector labels
 */}}
 {{- define "infinispan-helm-charts.selectorLabels" -}}
+{{- if .Values.deploy.usePrefixedLabels }}
+infinispan_clusterName: {{ include "infinispan-helm-charts.name" . }}
+infinispan_app: infinispan-pod
+{{- else }}
 clusterName: {{ include "infinispan-helm-charts.name" . }}
 app: infinispan-pod
+{{- end }}
 {{- end }}
 
 {{/*

--- a/templates/helpers.tpl
+++ b/templates/helpers.tpl
@@ -77,10 +77,10 @@ Service custom labels
 Service selector labels
 */}}
 {{- define "infinispan-helm-charts.selectorLabels" -}}
-{{- if .Values.deploy.usePrefixedLabels }}
+{{- if .Values.deploy.usePrefixedLabels -}}
 infinispan_clusterName: {{ include "infinispan-helm-charts.name" . }}
 infinispan_app: infinispan-pod
-{{- else }}
+{{- else -}}
 clusterName: {{ include "infinispan-helm-charts.name" . }}
 app: infinispan-pod
 {{- end }}

--- a/templates/statefulset.yaml
+++ b/templates/statefulset.yaml
@@ -13,8 +13,7 @@ spec:
   replicas: {{ .Values.deploy.replicas }}
   selector:
     matchLabels:
-      app: infinispan-pod
-      clusterName: {{ include "infinispan-helm-charts.name" . }}
+      {{- include "infinispan-helm-charts.selectorLabels" . | nindent 6 }}
   template:
     metadata:
       annotations:
@@ -24,8 +23,7 @@ spec:
         {{- end }}
         {{- include "infinispan-helm-charts.podAnnotations" . | nindent 8 }}
       labels:
-        app: infinispan-pod
-        clusterName: {{ include "infinispan-helm-charts.name" . }}
+        {{- include "infinispan-helm-charts.selectorLabels" . | nindent 8 }}
         {{- include "infinispan-helm-charts.podLabels" . | nindent 8 }}
     spec:
       {{- if .Values.deploy.nodeSelector }}

--- a/values.yaml
+++ b/values.yaml
@@ -77,6 +77,8 @@ deploy:
 
   makeDataDirWritable: false
 
+  usePrefixedLabels: false
+
   nameOverride: ""
 
   resourceLabels: []
@@ -101,8 +103,7 @@ deploy:
       - podAffinityTerm:
           labelSelector:
             matchLabels:
-              clusterName: {{ include "infinispan-helm-charts.name" . }}
-              app: infinispan-pod
+              {{- include "infinispan-helm-charts.selectorLabels" . | nindent 14 }}
           topologyKey: kubernetes.io/hostname
         weight: 100
 

--- a/values.yaml
+++ b/values.yaml
@@ -103,7 +103,7 @@ deploy:
       - podAffinityTerm:
           labelSelector:
             matchLabels:
-              {{- include "infinispan-helm-charts.selectorLabels" . | nindent 14 }}
+              {{- include "infinispan-helm-charts.selectorLabels" . | nindent 10 }}
           topologyKey: kubernetes.io/hostname
         weight: 100
 


### PR DESCRIPTION
### Description
  This PR Fix: Selector label collisions with external admission controllers (e.g., Kyverno)**

  The StatefulSet selector and pod template used generic label keys (`app`, `clusterName`) that can be overridden by admission controllers such as Kyverno, which automatically inject labels like `app:
  <resource-name>` onto pods. When Kyverno overwrites `app: infinispan-pod` with `app: <release-name>`, the pod labels no longer match the StatefulSet selector (an immutable field), causing the
  StatefulSet to fail with:
  `selector does not match template labels`

  A new flag `deploy.usePrefixedLabels` (default: `false`) has been introduced to replace the generic selector label keys with project-specific prefixed alternatives:
  - `app` → `infinispan_app`
  - `clusterName` → `infinispan_clusterName`

  The flag defaults to `false` to preserve backwards compatibility. Setting it to `true` switches all selector labels (StatefulSet selector, pod template labels, service selectors, and the default
  `podAntiAffinity` rule) to the prefixed variants via a single conditional in the `selectorLabels` helper.

  > **Note:** Changing `deploy.usePrefixedLabels` on an existing cluster requires deleting and recreating the StatefulSet due to the immutability of the `selector` field.

  ### Verification conducted
  - **Selector fix — After (`usePrefixedLabels: true`):** Selector uses `infinispan_clusterName` and `infinispan_app`, which Kyverno does not inject, preventing any collision.